### PR TITLE
Wok 509 better voyant export - add XML export

### DIFF
--- a/src/main/java/dk/kb/labsapi/SolrExport.java
+++ b/src/main/java/dk/kb/labsapi/SolrExport.java
@@ -271,10 +271,10 @@ public class SolrExport extends SolrBase {
                     writer.writeComment("query: " + query.replace("\n", "\\n"));
                     writer.writeComment("fields: " + fields.toString());
                     synchronized (HUMAN_TIME) {
-                        writer.writeComment("# export time: " + HUMAN_TIME.format(new Date()));
+                        writer.writeComment("export time: " + HUMAN_TIME.format(new Date()));
                     }
-                    writer.writeComment("# matched articles: " + countHits(query));
-                    writer.writeComment("# max articles returned: " + max);
+                    writer.writeComment("matched articles: " + countHits(query));
+                    writer.writeComment("max articles returned: " + max);
                 }
                 writer.writeStartElement("results");
                 // root <results>

--- a/src/main/java/dk/kb/labsapi/api/impl/LabsapiService.java
+++ b/src/main/java/dk/kb/labsapi/api/impl/LabsapiService.java
@@ -210,6 +210,10 @@ public class LabsapiService implements LabsapiApi {
                 httpServletResponse.setContentType("text/plain;charset=UTF-8");
                 break;
             }
+            case xml: {
+                httpServletResponse.setContentType("text/xml;charset=UTF-8");
+                break;
+            }
             default: throw new InternalServiceException(
                     "Internal exception: format '" + trueFormat + "' could not be converted to MIME type");
         }

--- a/src/main/openapi/openapi.yaml
+++ b/src/main/openapi/openapi.yaml
@@ -37,6 +37,7 @@ paths:
                       A filter restricting the result to newspapers older than 140 years will be automatically applied
           schema:
             type: string
+            # TODO: Change example - confusing that the example lets py extend to 1899, while the application only allows py to 1880
             example: 'cykel AND lplace:København AND py:[1850 TO 1899]'
         - name: fields
           in: query
@@ -108,9 +109,11 @@ paths:
                       |JSON|Valid JSON in the form of a single array of Documents.|
                       |JSONL|Newline separated single-line JSON representations of Documents.|
                       |TXT|Plain text output. UTF-8 Encoded.|
+                      |XML|XML output. UTF-8 Encoded.|
           schema:
             type: string
             enum:  ['CSV', 'JSON', 'JSONL', 'TXT', 'XML']
+            # TODO: When default value is CSV it would make more sense to have the example value be CSV as well?
             default: 'CSV'
             example: 'JSON'
 

--- a/src/main/openapi/openapi.yaml
+++ b/src/main/openapi/openapi.yaml
@@ -88,7 +88,7 @@ paths:
           description: |
                       |The major parts of the delivery| |
                       |---|---|
-                      |comments|Metadata for the export (query, export time...), prefixed with # in CSV, not shown in JSON|
+                      |comments|Metadata for the export (query, export time...), prefixed with # in CSV, encapsulated in <--!XML comment--> in XML  and not shown in JSON|
                       |header|The export field names. Only relevant for CSV|
                       |content|The export content itself|
           schema:

--- a/src/main/openapi/openapi.yaml
+++ b/src/main/openapi/openapi.yaml
@@ -110,7 +110,7 @@ paths:
                       |TXT|Plain text output. UTF-8 Encoded.|
           schema:
             type: string
-            enum:  ['CSV', 'JSON', 'JSONL', 'TXT']
+            enum:  ['CSV', 'JSON', 'JSONL', 'TXT', 'XML']
             default: 'CSV'
             example: 'JSON'
 

--- a/src/main/openapi/openapi.yaml
+++ b/src/main/openapi/openapi.yaml
@@ -88,9 +88,9 @@ paths:
           description: |
                       |The major parts of the delivery| |
                       |---|---|
-                      |comments|Metadata for the export (query, export time...), prefixed with # in CSV, encapsulated in <--!XML comment--> in XML  and not shown in JSON|
-                      |header|The export field names. Only relevant for CSV|
-                      |content|The export content itself|
+                      |comments|Metadata for the export (query, export time...), prefixed with # in CSV, encapsulated in <--!XML comment--> in XML  and not shown in JSON.|
+                      |header|The export field names. Only relevant for CSV.|
+                      |content|The export content itself.|
           schema:
             type: array
             items:

--- a/src/main/openapi/openapi.yaml
+++ b/src/main/openapi/openapi.yaml
@@ -109,7 +109,7 @@ paths:
                       |JSON|Valid JSON in the form of a single array of Documents.|
                       |JSONL|Newline separated single-line JSON representations of Documents.|
                       |TXT|Plain text output. UTF-8 Encoded.|
-                      |XML|XML output. UTF-8 Encoded.|
+                      |XML|XML output. UTF-8 Encoded. <br/>This output format is [Voyant](https://voyant-tools.org/docs/#!/guide/about) compliant and makes it possible to export newspaper data directly to Voyant.|
           schema:
             type: string
             enum:  ['CSV', 'JSON', 'JSONL', 'TXT', 'XML']


### PR DESCRIPTION
This pull request implements XML format as response for `/aviser/export/fields` 

This is done to make it possible to export data to [Voyant](https://voyant-tools.org/) in a good way. This PR closes #27 

Document segmentation in Voyant can be done directly from the api call by querying `/aviser/export/fields` and using the following settings when importing to Voyant: 
![image](https://user-images.githubusercontent.com/57002333/199696002-9c228d70-be78-4aec-bb95-17f8b82483c4.png)


