### PR TITLE
Implement deduplication + upper limit for image export

### DIFF
--- a/conf/labsapi-behaviour.yaml
+++ b/conf/labsapi-behaviour.yaml
@@ -21,6 +21,7 @@ labsapi:
       minYear: 1666 # Optional. Default is 1666
       maxYear: 1880 # Required. Maximum allowed is 1880
       url: 'https://example.com/?FIF=/avis-show/symlinks'
+      maxExport: 10000
 
     summarise:
       # A summarise server with newspaper material

--- a/src/main/openapi/openapi.yaml
+++ b/src/main/openapi/openapi.yaml
@@ -218,12 +218,15 @@ paths:
         - name: max
           in: query
           required: true
-          description: | 
-            Number of max results to return. For all results use -1.
+          description: |
+            Number of max results to return.
+            
+            Maximum allowed results per call are 10000.
           schema:
             type: integer
             format: int32
             default: 20
+            maximum: "${conf/labsapi*.yaml/lapsapi.aviser.imageServer.maxExport}"
 
       x-streamingOutput: true
       responses:
@@ -234,6 +237,12 @@ paths:
               schema:
                 type: string
                 format: binary
+        '500':
+          description: Parameters are probably out of range.
+          content:
+            text/plain:
+              schema:
+                type: string
 
   /aviser/export/alto:
     get:


### PR DESCRIPTION
This PR relates to #36 and #37.

Implements simple de-duplication and sets an upper bound of 10000 as max for image extraction.

- Is 10000 an appropriate limit?



closes #36 
closes #37 