### PR TITLE
Close zip entry

### DIFF
--- a/src/main/java/dk/kb/labsapi/ImageExport.java
+++ b/src/main/java/dk/kb/labsapi/ImageExport.java
@@ -230,6 +230,7 @@ public class ImageExport {
 
         OutputStream nonCloser = Utils.getNonCloser(zos);
         csvStream.forEach(csv -> Utils.safeStreamWrite(csv, nonCloser));
+        zos.closeEntry();
     }
 
     /**


### PR DESCRIPTION
tiny tiny tiny change, closes an open zip entry, which should make the endpoint return a CSV containing metadata. 
Deploying and testing tomorrow.